### PR TITLE
fix: harden CI workflow security (Node.js 22, SHA-pinned actions)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642195f2b846f4d15ff0c87  # v4.4.0
       with:
-        node-version: "16"
+        node-version: "22"
 
     - name: Install markdownlint-cli
-      run: npm install -g markdownlint-cli
+      run: npm install -g markdownlint-cli@0.44.0
         
     - name: Run markdownlint
       run: markdownlint "**/*.md" --ignore node_modules


### PR DESCRIPTION
## Summary
- Update Node.js from EOL v16 (Sept 2023) to Active LTS v22
- Pin GitHub Actions to commit SHAs to prevent tag-based supply-chain attacks
- Pin markdownlint-cli to v0.44.0 instead of unpinned latest

## Changes
| Before | After |
|--------|-------|
| `node-version: "16"` | `node-version: "22"` |
| `actions/checkout@v4` | `actions/checkout@11bd719...` (v4.2.2) |
| `actions/setup-node@v4` | `actions/setup-node@4993...` (v4.4.0) |
| `npm install -g markdownlint-cli` | `npm install -g markdownlint-cli@0.44.0` |

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] markdownlint passes on all .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)